### PR TITLE
# 4 Menu Component (Compound Components Exercise) finished

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,9 @@
+* {
+  box-sizing: border-box;
+}
 
-body{
+
+body {
   width: 100vw;
   height: 100vh;
   /*border: 3px solid black;*/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import './App.css'
-import AvatarApp from './components/avatar-overloaded/AvatarApp'
+
+import MenuApp from './components/Menu/MenuApp'
 
 
 
@@ -7,6 +8,7 @@ import AvatarApp from './components/avatar-overloaded/AvatarApp'
 import PropsButton from './components/props-review-button/PropsButton'
 import Marquee from './components/marquee/Marquee'
 import LoginButtonApp from './components/login-w-google-button/LoginButtonApp'
+import AvatarApp from './components/avatar-overloaded/AvatarApp'
 */
 
 
@@ -16,7 +18,8 @@ function App() {
   return (
     <>
       <h1>I am App</h1>
-      <AvatarApp />
+      <MenuApp />
+      {/*<MenuApp />*/}
       {/*<AvatarApp />*/}
       {/*<LoginButtonApp />*/}
       {/*<Marquee>🧛‍♀️ Welcome to Horrorville 🧛‍♀️</Marquee>*/}

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,0 +1,16 @@
+import "./assets/styles.css"
+import classNames from "classnames";
+
+
+export default function Button({ children, className, size, variant, ...rest }) {
+
+    let sizeClass = size && `button-${size}`
+    let variantClass = variant && `button-${variant}`
+    const allClasses = classNames(sizeClass, variantClass, className)
+
+    return (
+        <button className={allClasses} {...rest}>
+            {children}
+        </button>
+    )
+}

--- a/src/components/Button/assets/styles.css
+++ b/src/components/Button/assets/styles.css
@@ -1,0 +1,44 @@
+button {
+    background-color: #E5E7EB;
+    color: #4B5563;
+    border: 1px solid #6B7280;
+    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.05);
+    cursor: pointer;
+    font-weight: 700;
+    padding: 9px 17px;
+    border-radius: 6px;
+    line-height: 24px;
+    display: flex;
+    align-items: center;
+}
+
+button:focus {
+    outline: none;
+}
+
+button.button-sm {
+    padding: 7px 11px;
+    font-size: 12px;
+}
+
+button.button-lg {
+    padding: 13px 25px;
+}
+
+button.button-success {
+    color: #047857;
+    background-color: #ECFDF5;
+    border-color: #047857;
+}
+
+button.button-warning {
+    color: #FBBF24;
+    background-color: #FFFBEB;
+    border-color: #FBBF24;
+}
+
+button.button-danger {
+    color: #F87171;
+    background-color: #FEF2F2;
+    border-color: #F87171;
+}

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -1,0 +1,33 @@
+import React from "react"
+import MenuButton from "./MenuButton"
+import MenuDropdown from "./MenuDropdown"
+
+export default function Menu({ buttonText = "Menu", items }) {
+    /**
+     * Note: leave the div className="menu" here and render
+     * the children inside that div. Notice this component will become
+     * significantly simpler by doing so 💡
+     * 
+     * Also, notice our state will be broken after we make 
+     * these changes - that's okay! We'll fix it soon. In the meantime,
+     * leave the useState() call and toggle() definitions alone. Your
+     * new version won't be using them, but we'll come back to them
+     * later.
+     */
+    const [open, setOpen] = React.useState(true)
+
+    function toggle() {
+        setOpen(prevOpen => !prevOpen)
+    }
+
+    return (
+        <div className="menu">
+            <MenuButton
+                buttonText={buttonText}
+                onClick={toggle}
+            />
+
+            {open && <MenuDropdown items={items} />}
+        </div>
+    )
+}

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 
-export default function Menu({ buttonText = "Menu", items }) {
+export default function Menu({ children }) {
     /**
      * Note: leave the div className="menu" here and render
      * the children inside that div. Notice this component will become
@@ -22,12 +22,7 @@ export default function Menu({ buttonText = "Menu", items }) {
 
     return (
         <div className="menu">
-            <MenuButton
-                buttonText={buttonText}
-                onClick={toggle}
-            />
-
-            {open && <MenuDropdown items={items} />}
+            {children}
         </div>
     )
 }

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -2,15 +2,10 @@ import React from "react"
 import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 
-/**
- * Challenge:
- * Now that MenuButton and MenuDropdown are receiving
- * `open` and `toggle`, accept the necessary props in
- * those components and refactor them to use those props
- * to make the menu work again!
- * 
- * Hint: in MenuDropdown, you'll need to use conditional
- * rendering to either display the div OR display `null`
+/** Discovery Challenge:
+ * In the MenuButton, MenuDropdown, and MenuItem components, 
+ * accept `toggle` and `open` props and just console log 
+ * both of them in all 3 components.
  */
 
 export default function Menu({ children }) {

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -1,40 +1,27 @@
 import React from "react"
-
-
-/**
- * Challenge:
- * Part 1:
- * 1. Create new context here in the Menu component. Make sure
- *    to export it from this file as well.
- * 2. Wrap the `div` below with the Context Provider
- * 3. Give the Provider a value of the boolean `false` (represents
- *    the hardcoded `open` state for now - we'll fix this very soon.)
- */
+import "./assets/styles.css"
 
 const MenuContext = React.createContext();
 
 export default function Menu({ children }) {
-
-    const [open, setOpen] = React.useState(true)
+    /**
+     * Challenge:
+     * Using what you know now, complete the Menu component so 
+     * everything is working again via Context + State
+     */
+    const [open, setOpen] = React.useState(false)
 
     function toggle() {
-        console.log("Toggled!")
         setOpen(prevOpen => !prevOpen)
     }
 
     return (
-        <MenuContext.Provider value={false}>
+        <MenuContext.Provider value={{ open, toggle }}>
             <div className="menu">
-                {React.Children.map(children, (child) => {
-                    return React.cloneElement(child, {
-                        open,
-                        toggle
-                    })
-                })}
+                {children}
             </div>
         </MenuContext.Provider>
     )
 }
 
-
-export {MenuContext}
+export { MenuContext }

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -3,16 +3,22 @@ import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 
 /**
- * Challenge: figure out what needs to be passed to the
- * children so they'll have access to new props!
+ * Challenge:
+ * Now that MenuButton and MenuDropdown are receiving
+ * `open` and `toggle`, accept the necessary props in
+ * those components and refactor them to use those props
+ * to make the menu work again!
+ * 
+ * Hint: in MenuDropdown, you'll need to use conditional
+ * rendering to either display the div OR display `null`
  */
-
 
 export default function Menu({ children }) {
 
     const [open, setOpen] = React.useState(true)
 
     function toggle() {
+        console.log("Toggled!")
         setOpen(prevOpen => !prevOpen)
     }
 
@@ -20,8 +26,8 @@ export default function Menu({ children }) {
         <div className="menu">
             {React.Children.map(children, (child) => {
                 return React.cloneElement(child, {
-                    open: open,
-                    toggle: toggle
+                    open,
+                    toggle
                 })
             })}
         </div>

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -1,12 +1,17 @@
 import React from "react"
-import MenuButton from "./MenuButton"
-import MenuDropdown from "./MenuDropdown"
 
-/** Discovery Challenge:
- * In the MenuButton, MenuDropdown, and MenuItem components, 
- * accept `toggle` and `open` props and just console log 
- * both of them in all 3 components.
+
+/**
+ * Challenge:
+ * Part 1:
+ * 1. Create new context here in the Menu component. Make sure
+ *    to export it from this file as well.
+ * 2. Wrap the `div` below with the Context Provider
+ * 3. Give the Provider a value of the boolean `false` (represents
+ *    the hardcoded `open` state for now - we'll fix this very soon.)
  */
+
+const MenuContext = React.createContext();
 
 export default function Menu({ children }) {
 
@@ -18,13 +23,18 @@ export default function Menu({ children }) {
     }
 
     return (
-        <div className="menu">
-            {React.Children.map(children, (child) => {
-                return React.cloneElement(child, {
-                    open,
-                    toggle
-                })
-            })}
-        </div>
+        <MenuContext.Provider value={false}>
+            <div className="menu">
+                {React.Children.map(children, (child) => {
+                    return React.cloneElement(child, {
+                        open,
+                        toggle
+                    })
+                })}
+            </div>
+        </MenuContext.Provider>
     )
 }
+
+
+export {MenuContext}

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -2,6 +2,12 @@ import React from "react"
 import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 
+/**
+ * Challenge: figure out what needs to be passed to the
+ * children so they'll have access to new props!
+ */
+
+
 export default function Menu({ children }) {
 
     const [open, setOpen] = React.useState(true)
@@ -12,7 +18,12 @@ export default function Menu({ children }) {
 
     return (
         <div className="menu">
-            {children}
+            {React.Children.map(children, (child) => {
+                return React.cloneElement(child, {
+                    open: open,
+                    toggle: toggle
+                })
+            })}
         </div>
     )
 }

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -3,17 +3,7 @@ import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 
 export default function Menu({ children }) {
-    /**
-     * Note: leave the div className="menu" here and render
-     * the children inside that div. Notice this component will become
-     * significantly simpler by doing so 💡
-     * 
-     * Also, notice our state will be broken after we make 
-     * these changes - that's okay! We'll fix it soon. In the meantime,
-     * leave the useState() call and toggle() definitions alone. Your
-     * new version won't be using them, but we'll come back to them
-     * later.
-     */
+
     const [open, setOpen] = React.useState(true)
 
     function toggle() {

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -1,6 +1,24 @@
 import "./assets/styles.css"
-
 import Menu from "./Menu"
+
+/**
+ * Challenge:
+ * 1. Convert the Menu component to use props.children 
+ *    instead of taking an `items` prop. (We'll update 
+ *    the MenuButton and MenuDropdown components later.) 
+ *    See note inside the Menu.js file for more info
+ * 
+ * 2. import MenuButton and MenuDropdown into THIS file
+ *    and render them as children of the Menu component. 
+ *    Remember to pass the buttonText and items array to 
+ *    the components that need those props to function.
+ *    (We'll also be updating that soon!)
+ * 
+ * NOTE: The functionality of the menu will be broken after 
+ * these changes, but that's okay! As such, don't worry 
+ * about moving the state or toggle function from the Menu; 
+ * there's more we need to learn before we can do that.
+ */
 
 export default function MenuApp() {
     

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -4,16 +4,13 @@ import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 
 /**
- * Challenge:
- * 1. Convert the MenuButton to accept children and 
- *    render them. (In this case, the children will
- *    just be the button text)
- * 2. Change the MenuButton below to pass "Sports"
- *    in as a child of the component instead of by
- *    using the `buttonText` prop.
- * 
- * NOTE: It's fine that the menu is still broken, I
- * promise we're getting there! 😃
+ * 1. MenuDropdown should render children instead of items
+ * 2. MenuItem (new component you need to create) should also
+ *    render children. Grab the <div className="menu-item">
+ *    from MenuDropdown before deleting it if you want to be
+ *    lazy :)
+ * 3. Map over the `sports` array inside MenuDropdown in this
+ *    file and render a MenuItem for each sport in the array
  */
 
 export default function MenuApp() {

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -4,7 +4,6 @@ import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 import MenuItem from "./MenuItem"
 
-
 export default function MenuApp() {
     let sports = ["Tennis", "Pickleball", "Racquetball", "Squash"]
     

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -1,3 +1,4 @@
+import React from "react"
 import "./assets/styles.css"
 import Menu from "./Menu"
 import MenuButton from "./MenuButton"

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -4,15 +4,6 @@ import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
 import MenuItem from "./MenuItem"
 
-/**
- * 1. MenuDropdown should render children instead of items
- * 2. MenuItem (new component you need to create) should also
- *    render children. Grab the <div className="menu-item">
- *    from MenuDropdown before deleting it if you want to be
- *    lazy :)
- * 3. Map over the `sports` array inside MenuDropdown in this
- *    file and render a MenuItem for each sport in the array
- */
 
 export default function MenuApp() {
     let sports = ["Tennis", "Pickleball", "Racquetball", "Squash"]

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -5,21 +5,15 @@ import MenuDropdown from "./MenuDropdown"
 
 /**
  * Challenge:
- * 1. Convert the Menu component to use props.children 
- *    instead of taking an `items` prop. (We'll update 
- *    the MenuButton and MenuDropdown components later.) 
- *    See note inside the Menu.js file for more info
+ * 1. Convert the MenuButton to accept children and 
+ *    render them. (In this case, the children will
+ *    just be the button text)
+ * 2. Change the MenuButton below to pass "Sports"
+ *    in as a child of the component instead of by
+ *    using the `buttonText` prop.
  * 
- * 2. import MenuButton and MenuDropdown into THIS file
- *    and render them as children of the Menu component. 
- *    Remember to pass the buttonText and items array to 
- *    the components that need those props to function.
- *    (We'll also be updating that soon!)
- * 
- * NOTE: The functionality of the menu will be broken after 
- * these changes, but that's okay! As such, don't worry 
- * about moving the state or toggle function from the Menu; 
- * there's more we need to learn before we can do that.
+ * NOTE: It's fine that the menu is still broken, I
+ * promise we're getting there! 😃
  */
 
 export default function MenuApp() {

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -1,0 +1,16 @@
+import "./assets/styles.css"
+
+import Menu from "./Menu"
+
+export default function MenuApp() {
+    
+    return (
+        <>
+            <h2>I am MenuApp</h2>
+            <Menu
+                buttonText="Sports"
+                items={["Tennis", "Pickleball", "Racquetball", "Squash"]}
+            />
+        </>
+    )
+}

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -2,6 +2,7 @@ import "./assets/styles.css"
 import Menu from "./Menu"
 import MenuButton from "./MenuButton"
 import MenuDropdown from "./MenuDropdown"
+import MenuItem from "./MenuItem"
 
 /**
  * 1. MenuDropdown should render children instead of items
@@ -14,13 +15,18 @@ import MenuDropdown from "./MenuDropdown"
  */
 
 export default function MenuApp() {
+    let sports = ["Tennis", "Pickleball", "Racquetball", "Squash"]
     
     return (
         <>
             <h2>I am MenuApp</h2>
             <Menu>
                 <MenuButton>Sports</MenuButton>
-                <MenuDropdown items={["Tennis", "Pickleball", "Racquetball", "Squash"]} />
+                <MenuDropdown>
+                    {sports.map(sport => 
+                        <MenuItem>{ sport }</MenuItem>
+                    )}
+                </MenuDropdown>
             </Menu>
             
         </>

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -24,7 +24,7 @@ export default function MenuApp() {
                 <MenuButton>Sports</MenuButton>
                 <MenuDropdown>
                     {sports.map(sport => 
-                        <MenuItem>{ sport }</MenuItem>
+                        <MenuItem key={sport}>{ sport }</MenuItem>
                     )}
                 </MenuDropdown>
             </Menu>

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -1,5 +1,7 @@
 import "./assets/styles.css"
 import Menu from "./Menu"
+import MenuButton from "./MenuButton"
+import MenuDropdown from "./MenuDropdown"
 
 /**
  * Challenge:

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -27,10 +27,11 @@ export default function MenuApp() {
     return (
         <>
             <h2>I am MenuApp</h2>
-            <Menu
-                buttonText="Sports"
-                items={["Tennis", "Pickleball", "Racquetball", "Squash"]}
-            />
+            <Menu>
+                <MenuButton buttonText="Sports" />
+                <MenuDropdown items={["Tennis", "Pickleball", "Racquetball", "Squash"]} />
+            </Menu>
+            
         </>
     )
 }

--- a/src/components/Menu/MenuApp.jsx
+++ b/src/components/Menu/MenuApp.jsx
@@ -22,7 +22,7 @@ export default function MenuApp() {
         <>
             <h2>I am MenuApp</h2>
             <Menu>
-                <MenuButton buttonText="Sports" />
+                <MenuButton>Sports</MenuButton>
                 <MenuDropdown items={["Tennis", "Pickleball", "Racquetball", "Squash"]} />
             </Menu>
             

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -2,6 +2,8 @@
 import Button from "../Button/Button"
 
 export default function MenuButton({ children, toggle, open }) {
+    console.log("MenuButton toggle:", toggle);
+    console.log("MenuButton open:", open);
     return (
         <Button onClick={toggle}>{children}</Button>
     )

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -1,0 +1,8 @@
+
+import Button from "../Button/Button"
+
+export default function MenuButton({ buttonText, onClick }) {
+    return (
+        <Button onClick={onClick}>{buttonText}</Button>
+    )
+}

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -1,8 +1,8 @@
 
 import Button from "../Button/Button"
 
-export default function MenuButton({ buttonText, onClick }) {
+export default function MenuButton({ children, onClick }) {
     return (
-        <Button onClick={onClick}>{buttonText}</Button>
+        <Button onClick={onClick}>{children}</Button>
     )
 }

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -1,7 +1,7 @@
 
 import Button from "../Button/Button"
 
-export default function MenuButton({ children, toggle }) {
+export default function MenuButton({ children, toggle, open }) {
     return (
         <Button onClick={toggle}>{children}</Button>
     )

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -1,8 +1,8 @@
 
 import Button from "../Button/Button"
 
-export default function MenuButton({ children, onClick }) {
+export default function MenuButton({ children, toggle }) {
     return (
-        <Button onClick={onClick}>{children}</Button>
+        <Button onClick={toggle}>{children}</Button>
     )
 }

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -1,8 +1,11 @@
-
+import React from "react"
 import Button from "../Button/Button"
+import "./assets/styles.css"
+import { MenuContext } from "./Menu"
 
-export default function MenuButton({ children, toggle }) {
 
+export default function MenuButton({ children }) {
+    const {toggle } = React.useContext(MenuContext)
     return (
         <Button onClick={toggle}>{children}</Button>
     )

--- a/src/components/Menu/MenuButton.jsx
+++ b/src/components/Menu/MenuButton.jsx
@@ -1,9 +1,8 @@
 
 import Button from "../Button/Button"
 
-export default function MenuButton({ children, toggle, open }) {
-    console.log("MenuButton toggle:", toggle);
-    console.log("MenuButton open:", open);
+export default function MenuButton({ children, toggle }) {
+
     return (
         <Button onClick={toggle}>{children}</Button>
     )

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 
 
 export default function MenuDropdown({ children, open, toggle }) {
@@ -5,7 +6,12 @@ export default function MenuDropdown({ children, open, toggle }) {
     console.log("MenuDropdown open:", open); 
     return open ? (
         <div className="menu-dropdown">
-            {children}
+            {React.Children.map(children, (child) => {
+                return React.cloneElement(child, {
+                    open,
+                    toggle
+                })
+            })}
         </div>
     ) : null
 }

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,0 +1,19 @@
+
+
+
+export default function MenuDropdown({ items }) {
+    return (
+        <div className="menu-dropdown">
+            {items.map(
+                item => (
+                    <div
+                        className="menu-item"
+                        key={item}
+                    >
+                        {item}
+                    </div>
+                )
+            )}
+        </div>
+    )
+}

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,10 +1,9 @@
 
-import React from "react"
 
-export default function MenuDropdown({ children }) {
-    return (
-                    <div className="menu-dropdown">
-                        {children}
-                    </div>
-    )
+export default function MenuDropdown({ children, open }) {
+    return open ? (
+        <div className="menu-dropdown">
+            {children}
+        </div>
+    ) : null
 }

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,8 +1,18 @@
 import React from "react";
+import { MenuContext } from "./Menu";
+
+/**
+ * Challenge part 2:
+ * Pull in the value from context and update the conditional
+ * rendering code below to use that value instead of `open`,
+ * which used to be passed down via props.
+ */
 
 
-export default function MenuDropdown({ children, open }) {
-    return open ? (
+export default function MenuDropdown({ children }) {
+    const value = React.useContext(MenuContext)
+
+    return value ? (
         <div className="menu-dropdown">
             {children}
         </div>

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,18 +1,9 @@
 import React from "react"
 
-export default function MenuDropdown({ items }) {
+export default function MenuDropdown({ children }) {
     return (
-        <div className="menu-dropdown">
-            {items.map(
-                item => (
-                    <div
-                        className="menu-item"
-                        key={item}
-                    >
-                        {item}
+                    <div className="menu-dropdown">
+                        {children}
                     </div>
-                )
-            )}
-        </div>
     )
 }

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,16 +1,9 @@
-import React from "react";
-import { MenuContext } from "./Menu";
-
-/**
- * Challenge part 2:
- * Pull in the value from context and update the conditional
- * rendering code below to use that value instead of `open`,
- * which used to be passed down via props.
- */
-
+import React from "react"
+import "./assets/styles.css"
+import { MenuContext } from "./Menu"
 
 export default function MenuDropdown({ children }) {
-    const open = React.useContext(MenuContext)
+    const { open }= React.useContext(MenuContext)
 
     return open ? (
         <div className="menu-dropdown">

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,6 +1,8 @@
 
 
 export default function MenuDropdown({ children, open, toggle }) {
+    console.log("MenuDropdown toggle:", toggle);
+    console.log("MenuDropdown open:", open); 
     return open ? (
         <div className="menu-dropdown">
             {children}

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,17 +1,10 @@
 import React from "react";
 
 
-export default function MenuDropdown({ children, open, toggle }) {
-    console.log("MenuDropdown toggle:", toggle);
-    console.log("MenuDropdown open:", open); 
+export default function MenuDropdown({ children, open }) {
     return open ? (
         <div className="menu-dropdown">
-            {React.Children.map(children, (child) => {
-                return React.cloneElement(child, {
-                    open,
-                    toggle
-                })
-            })}
+            {children}
         </div>
     ) : null
 }

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,6 +1,6 @@
 
 
-export default function MenuDropdown({ children, open }) {
+export default function MenuDropdown({ children, open, toggle }) {
     return open ? (
         <div className="menu-dropdown">
             {children}

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -10,9 +10,9 @@ import { MenuContext } from "./Menu";
 
 
 export default function MenuDropdown({ children }) {
-    const value = React.useContext(MenuContext)
+    const open = React.useContext(MenuContext)
 
-    return value ? (
+    return open ? (
         <div className="menu-dropdown">
             {children}
         </div>

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,5 +1,4 @@
-
-
+import React from "react"
 
 export default function MenuDropdown({ items }) {
     return (

--- a/src/components/Menu/MenuDropdown.jsx
+++ b/src/components/Menu/MenuDropdown.jsx
@@ -1,3 +1,4 @@
+
 import React from "react"
 
 export default function MenuDropdown({ children }) {

--- a/src/components/Menu/MenuItem.jsx
+++ b/src/components/Menu/MenuItem.jsx
@@ -1,0 +1,7 @@
+
+
+export default function MenuItem() {
+    return (
+        <h2>I am Menu Item</h2>
+    )
+}

--- a/src/components/Menu/MenuItem.jsx
+++ b/src/components/Menu/MenuItem.jsx
@@ -1,7 +1,6 @@
 
-export default function MenuItem({ children, toggle, open }) {
-    console.log("MenuItem toggle:", toggle);
-    console.log("MenuItem open:", open);
+export default function MenuItem({ children }) {
+
     return (
         <div className="menu-item">{ children }</div>
     )

--- a/src/components/Menu/MenuItem.jsx
+++ b/src/components/Menu/MenuItem.jsx
@@ -1,5 +1,5 @@
 
-export default function MenuItem({ children }) {
+export default function MenuItem({ children, toggle, open }) {
     return (
         <div className="menu-item">{ children }</div>
     )

--- a/src/components/Menu/MenuItem.jsx
+++ b/src/components/Menu/MenuItem.jsx
@@ -1,5 +1,7 @@
 
 export default function MenuItem({ children, toggle, open }) {
+    console.log("MenuItem toggle:", toggle);
+    console.log("MenuItem open:", open);
     return (
         <div className="menu-item">{ children }</div>
     )

--- a/src/components/Menu/MenuItem.jsx
+++ b/src/components/Menu/MenuItem.jsx
@@ -1,7 +1,10 @@
 
-export default function MenuItem({ children }) {
+import "./assets/styles.css"
 
+export default function MenuItem({ children }) {
     return (
-        <div className="menu-item">{ children }</div>
+        <div className="menu-item">
+            {children}
+        </div>
     )
 }

--- a/src/components/Menu/MenuItem.jsx
+++ b/src/components/Menu/MenuItem.jsx
@@ -1,7 +1,6 @@
 
-
-export default function MenuItem() {
+export default function MenuItem({ children }) {
     return (
-        <h2>I am Menu Item</h2>
+        <div className="menu-item">{ children }</div>
     )
 }

--- a/src/components/Menu/assets/quiz.md
+++ b/src/components/Menu/assets/quiz.md
@@ -1,0 +1,22 @@
+# Compound Components Quiz
+
+1. How would you explain the concept of compound components in React to someone who
+   only knows the very basics of React?
+
+Components that work together to accomplish a greater objective than might make
+sense to try and accomplish with a single component alone.
+
+
+2. What are some examples of HTML elements that work together to add functionality
+   or styling to each other?
+
+<ul> & <li>, <select> & <option>, <table> & all the other table elements
+
+
+3. How can compound components help you avoid having to drill props multiple levels
+   down?
+   
+Compound component "flatten" the hierarchy that I would otherwise need to pass
+props through. Since I need to provide the children to render, the parent-most
+component has direct access to those "grandchild" components, to which it can
+pass whatever props it needs to pass directly.

--- a/src/components/Menu/assets/quiz.md
+++ b/src/components/Menu/assets/quiz.md
@@ -48,3 +48,10 @@ https://react.dev/reference/react/Children
     To solve it you have to map and clone children in MenuDropdown 
     (MenuDropdown children are MenuItems)
     If you forgot this, check MenuApp()
+
+
+# Reference
+
+https://scrimba.com/advanced-react-c02h/~010 (Assistive technologies)
+https://scrimba.com/links/learn-react-useid
+https://scrimba.com/advanced-react-c02h/~011 (Dot Syntax)

--- a/src/components/Menu/assets/quiz.md
+++ b/src/components/Menu/assets/quiz.md
@@ -41,4 +41,6 @@ https://react.dev/reference/react/Children
      * both of them in all 3 components.
      */
 
-    
+    MenuButton and MenuDropdown log something, but MenuItem doesn't because 
+    it isn't a direct child of Menu, so it doesn't have access to toggle and open.
+    The log returns `undefined`

--- a/src/components/Menu/assets/quiz.md
+++ b/src/components/Menu/assets/quiz.md
@@ -35,3 +35,10 @@ pass whatever props it needs to pass directly.
 https://kentcdodds.com/blog/aha-programming 
 https://react.dev/reference/react/Children
 
+# Discovery Challenge:
+     * In the MenuButton, MenuDropdown, and MenuItem components, 
+     * accept `toggle` and `open` props and just console log 
+     * both of them in all 3 components.
+     */
+
+    

--- a/src/components/Menu/assets/quiz.md
+++ b/src/components/Menu/assets/quiz.md
@@ -10,7 +10,7 @@ sense to try and accomplish with a single component alone.
 2. What are some examples of HTML elements that work together to add functionality
    or styling to each other?
 
-<ul> & <li>, <select> & <option>, <table> & all the other table elements
+`<ul>` & `<li>`, `<select>` & `<option>`, `<table>` & all the other table elements
 
 
 3. How can compound components help you avoid having to drill props multiple levels
@@ -20,3 +20,18 @@ Compound component "flatten" the hierarchy that I would otherwise need to pass
 props through. Since I need to provide the children to render, the parent-most
 component has direct access to those "grandchild" components, to which it can
 pass whatever props it needs to pass directly.
+
+# Summary so Far
+[scrimba 1](https://scrimba.com/advanced-react-c02h/~0k) | [scrimba 2](https://scrimba.com/advanced-react-c02h/~0m)
+
+1. Moved the array of sports out of the Menu component.
+2. Create a MenuItem component that takes children.
+3. Map through the array of sports and add each one as a MenuItem into 
+   the MenuDropdown inside MenuApp.
+4. Fix MenuDropdown to take children 
+
+# Resources
+
+https://kentcdodds.com/blog/aha-programming 
+https://react.dev/reference/react/Children
+

--- a/src/components/Menu/assets/quiz.md
+++ b/src/components/Menu/assets/quiz.md
@@ -43,4 +43,8 @@ https://react.dev/reference/react/Children
 
     MenuButton and MenuDropdown log something, but MenuItem doesn't because 
     it isn't a direct child of Menu, so it doesn't have access to toggle and open.
-    The log returns `undefined`
+    The log returns `undefined`. 
+
+    To solve it you have to map and clone children in MenuDropdown 
+    (MenuDropdown children are MenuItems)
+    If you forgot this, check MenuApp()

--- a/src/components/Menu/assets/styles.css
+++ b/src/components/Menu/assets/styles.css
@@ -1,0 +1,55 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+}
+
+body {
+    background-color: #2f2f2f;
+    color: whitesmoke;
+    height: 100vh;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    margin-top: 40px;
+    font-family: Inter;
+}
+
+
+.menu {
+    position: relative;
+    display: inline-block;
+}
+
+.menu-button {
+    background-color: white;
+}
+
+.menu-dropdown {
+    position: absolute;
+    left: 0;
+    margin-top: 3px;
+    background-color: white;
+    border: 1px solid gray;
+    border-radius: 6px;
+    background-color: white;
+}
+
+.menu-item {
+    color: #4B5563;
+    padding: .75rem;
+    cursor: pointer;
+    min-width: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    user-select: none;
+}
+
+.menu-item:hover {
+    background-color: whitesmoke;
+}
+
+.menu-item:not(:last-child) {
+    border-bottom: 1px solid #6B7280;
+}


### PR DESCRIPTION
## Pull Request Summary: Menu Component – Compound Components Exercise

- chore: setup for Menu exercise for Compound Components  
- add challenge scaffolding and quizzes  
- convert `Menu` to use `props.children`  
- import and render `MenuButton` and `MenuDropdown` as children of `Menu`  
- convert `MenuButton` to accept and render children  
- create `MenuItem` component and map over a `sports` array  
- fix broken `MenuDropdown` to display hardcoded content  
- fix `MenuItem` and `MenuDropdown` classNames and structure, add `key` to `MenuItem`  
- make `MenuItem` render children  
- inject `open` and `toggle` props using `React.Children.map` and `React.cloneElement`  
- conditionally render `MenuDropdown` based on `open` state  
- discovery: `MenuItem` didn’t receive `toggle/open` props as expected  
- map and clone `MenuDropdown` children to pass down `open` and `toggle`  
- create and implement `MenuContext` in `Menu`  
- refactor conditional rendering logic to use `useContext`  
- rename `value` to `open` for clarity  
- complete the `Menu` component so everything is working again via Context
